### PR TITLE
Fix handling of byte arrays with Jackson

### DIFF
--- a/src/main/java/com/github/wnameless/json/base/JacksonJsonValue.java
+++ b/src/main/java/com/github/wnameless/json/base/JacksonJsonValue.java
@@ -50,7 +50,7 @@ public final class JacksonJsonValue implements JsonValueCore<JacksonJsonValue> {
 
   @Override
   public boolean isString() {
-    return jsonValue.isTextual();
+    return jsonValue.isTextual() || jsonValue.isBinary();
   }
 
   @Override

--- a/src/test/java/com/github/wnameless/json/base/JsonArrayBaseTest.java
+++ b/src/test/java/com/github/wnameless/json/base/JsonArrayBaseTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -43,6 +44,7 @@ public class JsonArrayBaseTest {
   long l = 1234567890123456789L;
   double d = 45.67;
   boolean bool = true;
+  byte[] bytes = "123".getBytes(StandardCharsets.UTF_8);
   Object obj = null;
   BigInteger bi = new BigInteger("1234567890123456789012345678901234567890");
   BigDecimal bd = new BigDecimal("45.678912367891236789123678912367891236789123");
@@ -61,6 +63,7 @@ public class JsonArrayBaseTest {
         }
       });
       setBool(bool);
+      setBytes(bytes);
       setObj(obj);
     }
   };

--- a/src/test/java/com/github/wnameless/json/base/JsonArrayCoreTest.java
+++ b/src/test/java/com/github/wnameless/json/base/JsonArrayCoreTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -45,6 +46,7 @@ public class JsonArrayCoreTest {
   long l = 1234567890123456789L;
   double d = 45.67;
   boolean bool = true;
+  byte[] bytes = "123".getBytes(StandardCharsets.UTF_8);
   Object obj = null;
   BigInteger bi = new BigInteger("1234567890123456789012345678901234567890");
   BigDecimal bd = new BigDecimal("45.678912367891236789123678912367891236789123");
@@ -63,6 +65,7 @@ public class JsonArrayCoreTest {
         }
       });
       setBool(bool);
+      setBytes(bytes);
       setObj(obj);
     }
   };

--- a/src/test/java/com/github/wnameless/json/base/JsonCoreTest.java
+++ b/src/test/java/com/github/wnameless/json/base/JsonCoreTest.java
@@ -40,13 +40,14 @@ import jakarta.json.JsonValue;
 public class JsonCoreTest {
 
   String json =
-      "{\"str\":\"text\",\"num\":[123,1234567890123456789,45.67,1234567890123456789012345678901234567890,45.678912367891236789123678912367891236789123],\"bool\":true,\"obj\":null}";
+      "{\"str\":\"text\",\"num\":[123,1234567890123456789,45.67,1234567890123456789012345678901234567890,45.678912367891236789123678912367891236789123],\"bool\":true,\"bytes\":null,\"obj\":null}";
 
   String str = "text";
   int i = 123;
   long l = 1234567890123456789L;
   double d = 45.67;
   boolean bool = true;
+  byte[] bytes = null;
   Object obj = null;
   BigInteger bi = new BigInteger("1234567890123456789012345678901234567890");
   BigDecimal bd = new BigDecimal("45.678912367891236789123678912367891236789123");
@@ -65,6 +66,7 @@ public class JsonCoreTest {
         }
       });
       setBool(bool);
+      setBytes(bytes);
       setObj(obj);
     }
   };
@@ -107,7 +109,7 @@ public class JsonCoreTest {
   public void testJacksonJsonCore() throws IOException {
     ObjectMapper mapper = new ObjectMapper();
     JsonNode jsonNode = mapper.valueToTree(jo);
-    jsonValue = new OrgJsonValue(json);
+    jsonValue = new JacksonJsonValue(jsonNode);
     assertNotEquals(jsonValue, new JacksonJsonCore().parse(json));
 
     mapper.enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS);
@@ -131,6 +133,7 @@ public class JsonCoreTest {
 
     jo.setObj(JSONObject.NULL);
     jsonObject = new JSONObject(jo);
+    jsonObject.put("bytes", JSONObject.NULL);
     jsonValue = new OrgJsonValue(jsonObject);
     assertEquals(jsonValue, new OrgJsonCore().parse(json));
 
@@ -148,7 +151,7 @@ public class JsonCoreTest {
   public void testJakartaJsonCore() throws IOException {
     jsonValue = new JakartaJsonValue(Json.createObjectBuilder().add("str", str)
         .add("num", Json.createArrayBuilder().add(i).add(l).add(d).add(bi).add(bd).build())
-        .add("bool", bool).add("obj", JsonValue.NULL).build());
+        .add("bool", bool).add("bytes", JsonValue.NULL).add("obj", JsonValue.NULL).build());
 
     assertEquals(jsonValue, new JakartaJsonCore().parse(json));
     assertEquals(jsonValue, new JakartaJsonCore().parse(new StringReader(json)));
@@ -164,7 +167,7 @@ public class JsonCoreTest {
 
     jsonValue = new JakartaJsonValue(Json.createObjectBuilder().add("str", str)
         .add("num", Json.createArrayBuilder().add(i).add(l).add(d).add(bi).add(bd).build())
-        .add("bool", bool).add("obj", JsonValue.NULL).build());
+        .add("bool", bool).add("bytes", JsonValue.NULL).add("obj", JsonValue.NULL).build());
 
     assertEquals(jsonValue, jjc.parse(json));
     assertEquals(jsonValue, jjc.parse(new StringReader(json)));

--- a/src/test/java/com/github/wnameless/json/base/JsonObjectBaseTest.java
+++ b/src/test/java/com/github/wnameless/json/base/JsonObjectBaseTest.java
@@ -21,8 +21,10 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -49,6 +51,7 @@ public class JsonObjectBaseTest {
   long l = 1234567890123456789L;
   double d = 45.67;
   boolean bool = true;
+  byte[] bytes = "123".getBytes(StandardCharsets.UTF_8);
   Object obj = null;
   BigInteger bi = new BigInteger("1234567890123456789012345678901234567890");
   BigDecimal bd = new BigDecimal("45.678912367891236789123678912367891236789123");
@@ -67,6 +70,7 @@ public class JsonObjectBaseTest {
         }
       });
       setBool(bool);
+      setBytes(bytes);
       setObj(obj);
     }
   };
@@ -95,13 +99,13 @@ public class JsonObjectBaseTest {
 
   @Test
   public void testNames() {
-    assertArrayEquals(new String[] {"str", "num", "bool", "obj"},
+    assertArrayEquals(new String[] {"str", "num", "bool", "bytes", "obj"},
         Iterators.toArray(gsonObj.names(), String.class));
 
-    assertArrayEquals(new String[] {"str", "num", "bool", "obj"},
+    assertArrayEquals(new String[] {"str", "num", "bool", "bytes", "obj"},
         Iterators.toArray(jacksonObj.names(), String.class));
 
-    assertEquals(new HashSet<>(Arrays.asList(new String[] {"str", "num", "bool", "obj"})),
+    assertEquals(new HashSet<>(Arrays.asList(new String[] {"str", "num", "bool", "bytes", "obj"})),
         new HashSet<>(Arrays.asList(Iterators.toArray(orgObj.names(), String.class))));
 
     assertArrayEquals(new String[] {"str", "num", "bool", "obj"},
@@ -125,18 +129,21 @@ public class JsonObjectBaseTest {
   public void testGet() {
     assertEquals(str, gsonObj.get("str").asString());
     assertEquals(Arrays.asList(i, l, d, bi, bd), gsonObj.get("num").asArray().toList());
+    assertEquals(Arrays.asList((int) bytes[0], (int) bytes[1], (int) bytes[2]), gsonObj.get("bytes").asArray().toList());
     assertEquals(bool, gsonObj.get("bool").asBoolean());
     assertEquals(null, gsonObj.get("obj").asNull());
     assertEquals(null, gsonObj.get("none"));
 
     assertEquals(str, jacksonObj.get("str").asString());
     assertEquals(Arrays.asList(i, l, d, bi, bd), jacksonObj.get("num").asArray().toList());
+    assertEquals(Base64.getEncoder().encodeToString(bytes), jacksonObj.get("bytes").asString());
     assertEquals(bool, jacksonObj.get("bool").asBoolean());
     assertEquals(null, jacksonObj.get("obj").asNull());
     assertEquals(null, jacksonObj.get("none"));
 
     assertEquals(str, orgObj.get("str").asString());
     assertEquals(Arrays.asList(i, l, d, bi, bd), orgObj.get("num").asArray().toList());
+    assertEquals(Arrays.asList(bytes[0], bytes[1], bytes[2]), orgObj.get("bytes").asArray().toList());
     assertEquals(bool, orgObj.get("bool").asBoolean());
     assertEquals(null, orgObj.get("obj").asNull());
     assertEquals(null, orgObj.get("none"));
@@ -150,9 +157,9 @@ public class JsonObjectBaseTest {
 
   @Test
   public void testSize() {
-    assertEquals(4, gsonObj.size());
-    assertEquals(4, jacksonObj.size());
-    assertEquals(4, orgObj.size());
+    assertEquals(5, gsonObj.size());
+    assertEquals(5, jacksonObj.size());
+    assertEquals(5, orgObj.size());
     assertEquals(4, jakartaObj.size());
   }
 
@@ -184,10 +191,13 @@ public class JsonObjectBaseTest {
     map.put("bool", bool);
     map.put("obj", obj);
 
-    assertEquals(map, gsonObj.toMap());
-    assertEquals(map, jacksonObj.toMap());
-    assertEquals(map, orgObj.toMap());
     assertEquals(map, jakartaObj.toMap());
+    map.put("bytes", Arrays.asList((int) bytes[0], (int) bytes[1], (int) bytes[2]));
+    assertEquals(map, gsonObj.toMap());
+    map.put("bytes", Base64.getEncoder().encodeToString(bytes));
+    assertEquals(map, jacksonObj.toMap());
+    map.put("bytes", Arrays.asList(bytes[0], bytes[1], bytes[2]));
+    assertEquals(map, orgObj.toMap());
   }
 
   @Test

--- a/src/test/java/com/github/wnameless/json/base/JsonObjectCoreTest.java
+++ b/src/test/java/com/github/wnameless/json/base/JsonObjectCoreTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import org.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
@@ -45,6 +46,7 @@ public class JsonObjectCoreTest {
   long l = 1234567890123456789L;
   double d = 45.67;
   boolean bool = true;
+  byte[] bytes = "123".getBytes(StandardCharsets.UTF_8);
   Object obj = null;
   BigInteger bi = new BigInteger("1234567890123456789012345678901234567890");
   BigDecimal bd = new BigDecimal("45.678912367891236789123678912367891236789123");
@@ -63,6 +65,7 @@ public class JsonObjectCoreTest {
         }
       });
       setBool(bool);
+      setBytes(bytes);
       setObj(obj);
     }
   };
@@ -117,9 +120,9 @@ public class JsonObjectCoreTest {
     orgObj.set("text", new OrgJsonCore().parse("\"str\""));
     jakartaObj.set("text", new JakartaJsonCore().parse("\"str\""));
 
-    assertEquals(5, gsonObj.size());
-    assertEquals(5, jacksonObj.size());
-    assertEquals(5, orgObj.size());
+    assertEquals(6, gsonObj.size());
+    assertEquals(6, jacksonObj.size());
+    assertEquals(6, orgObj.size());
     assertEquals(5, jakartaObj.size());
 
     assertEquals("str", gsonObj.get("text").asString());

--- a/src/test/java/com/github/wnameless/json/base/JsonPOJO.java
+++ b/src/test/java/com/github/wnameless/json/base/JsonPOJO.java
@@ -22,6 +22,7 @@ public class JsonPOJO {
   private String str;
   private List<?> num;
   private boolean bool;
+  private byte[] bytes;
   private Object obj;
 
   public String getStr() {
@@ -46,6 +47,14 @@ public class JsonPOJO {
 
   public void setBool(boolean bool) {
     this.bool = bool;
+  }
+
+  public byte[] getBytes() {
+    return bytes;
+  }
+
+  public void setBytes(byte[] bytes) {
+    this.bytes = bytes;
   }
 
   public Object getObj() {

--- a/src/test/java/com/github/wnameless/json/base/JsonValueBaseTest.java
+++ b/src/test/java/com/github/wnameless/json/base/JsonValueBaseTest.java
@@ -22,8 +22,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -49,6 +51,7 @@ public class JsonValueBaseTest {
   long l = 1234567890123456789L;
   double d = 45.67;
   boolean bool = true;
+  byte[] bytes = "123".getBytes(StandardCharsets.UTF_8);
   Object obj = null;
   BigInteger bi = new BigInteger("1234567890123456789012345678901234567890");
   BigDecimal bd = new BigDecimal("45.678912367891236789123678912367891236789123");
@@ -67,6 +70,7 @@ public class JsonValueBaseTest {
         }
       });
       setBool(bool);
+      setBytes(bytes);
       setObj(obj);
     }
   };
@@ -123,6 +127,13 @@ public class JsonValueBaseTest {
     assertEquals(bi, jsonValue.asObject().get("num").asArray().get(3).asNumber());
     assertEquals(bd, jsonValue.asObject().get("num").asArray().get(4).asBigDecimal());
     assertEquals(bd, jsonValue.asObject().get("num").asArray().get(4).asNumber());
+    assertTrue(jsonValue.asObject().get("bytes").isArray());
+    assertTrue(jsonValue.asObject().get("bytes").asArray().get(0).isNumber());
+    assertEquals((int) bytes[0], jsonValue.asObject().get("bytes").asArray().get(0).asNumber());
+    assertTrue(jsonValue.asObject().get("bytes").asArray().get(1).isNumber());
+    assertEquals((int) bytes[1], jsonValue.asObject().get("bytes").asArray().get(1).asNumber());
+    assertTrue(jsonValue.asObject().get("bytes").asArray().get(2).isNumber());
+    assertEquals((int) bytes[2], jsonValue.asObject().get("bytes").asArray().get(2).asNumber());
     assertTrue(jsonValue.asObject().get("obj").isNull());
     assertSame(null, jsonValue.asObject().get("obj").asNull());
 
@@ -154,10 +165,10 @@ public class JsonValueBaseTest {
     JsonElement jsonElement = gson.toJsonTree(jo, new TypeToken<JsonPOJO>() {}.getType());
     GsonJsonValue jsonValue = new GsonJsonValue(jsonElement);
     assertEquals(
-        "{\"str\":\"text\",\"num\":[123,1234567890123456789,45.67,1234567890123456789012345678901234567890,45.678912367891236789123678912367891236789123],\"bool\":true,\"obj\":null}",
+        "{\"str\":\"text\",\"num\":[123,1234567890123456789,45.67,1234567890123456789012345678901234567890,45.678912367891236789123678912367891236789123],\"bool\":true,\"bytes\":[49,50,51],\"obj\":null}",
         jsonValue.toJson());
     assertEquals(
-        "{\"str\":\"text\",\"num\":[123,1234567890123456789,45.67,1234567890123456789012345678901234567890,45.678912367891236789123678912367891236789123],\"bool\":true,\"obj\":null}",
+        "{\"str\":\"text\",\"num\":[123,1234567890123456789,45.67,1234567890123456789012345678901234567890,45.678912367891236789123678912367891236789123],\"bool\":true,\"bytes\":[49,50,51],\"obj\":null}",
         jsonValue.asObject().toJson());
     assertEquals(
         "[123,1234567890123456789,45.67,1234567890123456789012345678901234567890,45.678912367891236789123678912367891236789123]",
@@ -191,6 +202,8 @@ public class JsonValueBaseTest {
     assertEquals(bi, jsonValue.asObject().get("num").asArray().get(3).asNumber());
     assertEquals(bd, jsonValue.asObject().get("num").asArray().get(4).asBigDecimal());
     assertEquals(bd, jsonValue.asObject().get("num").asArray().get(4).asNumber());
+    assertTrue(jsonValue.asObject().get("bytes").isString());
+    assertEquals(Base64.getEncoder().encodeToString(bytes), jsonValue.asObject().get("bytes").asString());
     assertTrue(jsonValue.asObject().get("obj").isNull());
     assertSame(null, jsonValue.asObject().get("obj").asNull());
 
@@ -221,10 +234,10 @@ public class JsonValueBaseTest {
     JsonNode jsonNode = new ObjectMapper().valueToTree(jo);
     JacksonJsonValue jsonValue = new JacksonJsonValue(jsonNode);
     assertEquals(
-        "{\"str\":\"text\",\"num\":[123,1234567890123456789,45.67,1234567890123456789012345678901234567890,45.678912367891236789123678912367891236789123],\"bool\":true,\"obj\":null}",
+        "{\"str\":\"text\",\"num\":[123,1234567890123456789,45.67,1234567890123456789012345678901234567890,45.678912367891236789123678912367891236789123],\"bool\":true,\"bytes\":\"MTIz\",\"obj\":null}",
         jsonValue.toJson());
     assertEquals(
-        "{\"str\":\"text\",\"num\":[123,1234567890123456789,45.67,1234567890123456789012345678901234567890,45.678912367891236789123678912367891236789123],\"bool\":true,\"obj\":null}",
+        "{\"str\":\"text\",\"num\":[123,1234567890123456789,45.67,1234567890123456789012345678901234567890,45.678912367891236789123678912367891236789123],\"bool\":true,\"bytes\":\"MTIz\",\"obj\":null}",
         jsonValue.asObject().toJson());
     assertEquals(
         "[123,1234567890123456789,45.67,1234567890123456789012345678901234567890,45.678912367891236789123678912367891236789123]",
@@ -258,6 +271,14 @@ public class JsonValueBaseTest {
     assertEquals(bi, jsonValue.asObject().get("num").asArray().get(3).asNumber());
     assertEquals(bd, jsonValue.asObject().get("num").asArray().get(4).asBigDecimal());
     assertEquals(bd, jsonValue.asObject().get("num").asArray().get(4).asNumber());
+    assertTrue(jsonValue.asObject().get("bytes").isArray());
+    assertTrue(jsonValue.asObject().get("bytes").asArray().get(0).isNumber());
+    assertEquals(bytes[0], jsonValue.asObject().get("bytes").asArray().get(0).asNumber());
+    assertTrue(jsonValue.asObject().get("bytes").asArray().get(1).isNumber());
+    assertEquals(bytes[1], jsonValue.asObject().get("bytes").asArray().get(1).asNumber());
+    assertTrue(jsonValue.asObject().get("bytes").asArray().get(2).isNumber());
+    assertEquals(bytes[2], jsonValue.asObject().get("bytes").asArray().get(2).asNumber());
+    assertTrue(jsonValue.asObject().get("obj").isNull());
     assertTrue(jsonValue.asObject().get("obj").isNull());
     assertSame(null, jsonValue.asObject().get("obj").asNull());
 
@@ -291,10 +312,10 @@ public class JsonValueBaseTest {
     jo.setObj(JSONObject.NULL);
     jsonValue = new OrgJsonValue(new JSONObject(jo));
     assertEquals(new OrgJsonCore().parse(
-        "{\"str\":\"text\",\"num\":[123,1234567890123456789,45.67,1234567890123456789012345678901234567890,45.678912367891236789123678912367891236789123],\"bool\":true,\"obj\":null}"),
+        "{\"str\":\"text\",\"num\":[123,1234567890123456789,45.67,1234567890123456789012345678901234567890,45.678912367891236789123678912367891236789123],\"bool\":true,\"bytes\":[49,50,51],\"obj\":null}"),
         new OrgJsonCore().parse(jsonValue.toJson()));
     assertEquals(new OrgJsonCore().parse(
-        "{\"str\":\"text\",\"num\":[123,1234567890123456789,45.67,1234567890123456789012345678901234567890,45.678912367891236789123678912367891236789123],\"bool\":true,\"obj\":null}"),
+        "{\"str\":\"text\",\"num\":[123,1234567890123456789,45.67,1234567890123456789012345678901234567890,45.678912367891236789123678912367891236789123],\"bool\":true,\"bytes\":[49,50,51],\"obj\":null}"),
         new OrgJsonCore().parse(jsonValue.asObject().toJson()));
     assertEquals(
         "[123,1234567890123456789,45.67,1234567890123456789012345678901234567890,45.678912367891236789123678912367891236789123]",
@@ -417,6 +438,10 @@ public class JsonValueBaseTest {
     assertEquals(gsonObject.get("bool"), element.getValue());
 
     element = iter.next();
+    assertEquals("bytes", element.getKey());
+    assertEquals(gsonObject.get("bytes"), element.getValue());
+
+    element = iter.next();
     assertEquals("obj", element.getKey());
     assertEquals(gsonObject.get("obj"), element.getValue());
 
@@ -472,6 +497,10 @@ public class JsonValueBaseTest {
     assertEquals(jacksonObject.get("bool"), element.getValue());
 
     element = iter.next();
+    assertEquals("bytes", element.getKey());
+    assertEquals(jacksonObject.get("bytes"), element.getValue());
+
+    element = iter.next();
     assertEquals("obj", element.getKey());
     assertEquals(jacksonObject.get("obj"), element.getValue());
 
@@ -524,6 +553,11 @@ public class JsonValueBaseTest {
 
     element = iter.next();
     // assertEquals("bool", element.getKey());
+    assertEquals(orgObject.get(element.getKey()), element.getValue());
+    keys.remove(element.getKey());
+
+    element = iter.next();
+    // assertEquals("bytes", element.getKey());
     assertEquals(orgObject.get(element.getKey()), element.getValue());
     keys.remove(element.getKey());
 

--- a/src/test/java/com/github/wnameless/json/base/JsonValueCoreTest.java
+++ b/src/test/java/com/github/wnameless/json/base/JsonValueCoreTest.java
@@ -18,6 +18,7 @@ package com.github.wnameless.json.base;
 import static org.junit.Assert.assertSame;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
@@ -38,6 +39,7 @@ public class JsonValueCoreTest {
   long l = 1234567890123456789L;
   double d = 45.67;
   boolean bool = true;
+  byte[] bytes = "123".getBytes(StandardCharsets.UTF_8);
   Object obj = null;
   BigInteger bi = new BigInteger("1234567890123456789012345678901234567890");
   BigDecimal bd = new BigDecimal("45.678912367891236789123678912367891236789123");
@@ -56,6 +58,7 @@ public class JsonValueCoreTest {
         }
       });
       setBool(bool);
+      setBytes(bytes);
       setObj(obj);
     }
   };

--- a/src/test/java/com/github/wnameless/json/base/JsonValueUtilsTest.java
+++ b/src/test/java/com/github/wnameless/json/base/JsonValueUtilsTest.java
@@ -39,6 +39,7 @@ public class JsonValueUtilsTest {
   long l = 1234567890123456789L;
   double d = 45.67;
   boolean bool = true;
+  byte[] bytes = null;
   Object obj = null;
   BigInteger bi = new BigInteger("1234567890123456789012345678901234567890");
   BigDecimal bd = new BigDecimal("45.678912367891236789123678912367891236789123");
@@ -58,6 +59,7 @@ public class JsonValueUtilsTest {
         }
       });
       setBool(bool);
+      setBytes(bytes);
       setObj(obj);
     }
   };


### PR DESCRIPTION
In Jackson,  byte arrays are serialized to a Base64 strings but are also mapped to BinaryNode for which `isTextual` is False.
So when calling
```java
JsonNode jsonNode = new ObjectMapper().valueToTree(jo);
JacksonJsonValue jsonValue = new JacksonJsonValue(jsonNode);
String json = jsonValue.tojson()
```
where `jo` is a POJO that contains a non-null `byte[]` field, then the field is not serialized and you get a null value.
See the modified `testJacksonValueToJson` for a full example.

This PR fixes this issue.
It also adds tests for byte arrays in a bunch of unit tests.

Enhancements to JSON handling:

* [`src/main/java/com/github/wnameless/json/base/JacksonJsonValue.java`](diffhunk://#diff-4226e38f3db33479ae7dc3fc8a7091e83986a3044ccf964ecdd183153ec604e3L53-R53): Modified the `isString` method for Jackson to return true for both textual and binary nodes.

Updates to test cases:

* [`src/test/java/com/github/wnameless/json/base/JsonArrayBaseTest.java`](diffhunk://#diff-cc1f05a1f96ec4ac5608d3355d96caef1b950af1ead4ea5635550c4b3accc6faR23): Added handling and testing for byte arrays, including new test data and assertions. [[1]](diffhunk://#diff-cc1f05a1f96ec4ac5608d3355d96caef1b950af1ead4ea5635550c4b3accc6faR23) [[2]](diffhunk://#diff-cc1f05a1f96ec4ac5608d3355d96caef1b950af1ead4ea5635550c4b3accc6faR47) [[3]](diffhunk://#diff-cc1f05a1f96ec4ac5608d3355d96caef1b950af1ead4ea5635550c4b3accc6faR66)
* [`src/test/java/com/github/wnameless/json/base/JsonCoreTest.java`](diffhunk://#diff-5becb1b8aeb66e1bc1f04b57e8de76a9d48ba5637c857aef8cc4679ed843125dL43-R50): Updated JSON strings and test methods to include byte arrays, ensuring compatibility with different JSON libraries. [[1]](diffhunk://#diff-5becb1b8aeb66e1bc1f04b57e8de76a9d48ba5637c857aef8cc4679ed843125dL43-R50) [[2]](diffhunk://#diff-5becb1b8aeb66e1bc1f04b57e8de76a9d48ba5637c857aef8cc4679ed843125dR69) [[3]](diffhunk://#diff-5becb1b8aeb66e1bc1f04b57e8de76a9d48ba5637c857aef8cc4679ed843125dR136) [[4]](diffhunk://#diff-5becb1b8aeb66e1bc1f04b57e8de76a9d48ba5637c857aef8cc4679ed843125dL151-R154) [[5]](diffhunk://#diff-5becb1b8aeb66e1bc1f04b57e8de76a9d48ba5637c857aef8cc4679ed843125dL167-R170)
* [`src/test/java/com/github/wnameless/json/base/JsonObjectBaseTest.java`](diffhunk://#diff-b12fd923846b787cd13d6536e358b3b329a1e22b4770dad8019a9ff6fb278c12R24-R27): Enhanced tests to verify the inclusion and proper handling of byte arrays in JSON objects. [[1]](diffhunk://#diff-b12fd923846b787cd13d6536e358b3b329a1e22b4770dad8019a9ff6fb278c12R24-R27) [[2]](diffhunk://#diff-b12fd923846b787cd13d6536e358b3b329a1e22b4770dad8019a9ff6fb278c12R54) [[3]](diffhunk://#diff-b12fd923846b787cd13d6536e358b3b329a1e22b4770dad8019a9ff6fb278c12R73) [[4]](diffhunk://#diff-b12fd923846b787cd13d6536e358b3b329a1e22b4770dad8019a9ff6fb278c12L98-R108) [[5]](diffhunk://#diff-b12fd923846b787cd13d6536e358b3b329a1e22b4770dad8019a9ff6fb278c12R132-R146) [[6]](diffhunk://#diff-b12fd923846b787cd13d6536e358b3b329a1e22b4770dad8019a9ff6fb278c12L153-R162) [[7]](diffhunk://#diff-b12fd923846b787cd13d6536e358b3b329a1e22b4770dad8019a9ff6fb278c12R194-L190)
* [`src/test/java/com/github/wnameless/json/base/JsonValueBaseTest.java`](diffhunk://#diff-21fbe64984a18c7c9fb221a28ca491bc64ad6ab2bc3d14d07291709047ebd0e5R25-R28): Added assertions for byte arrays in various JSON value tests, ensuring correct serialization and deserialization. [[1]](diffhunk://#diff-21fbe64984a18c7c9fb221a28ca491bc64ad6ab2bc3d14d07291709047ebd0e5R25-R28) [[2]](diffhunk://#diff-21fbe64984a18c7c9fb221a28ca491bc64ad6ab2bc3d14d07291709047ebd0e5R54) [[3]](diffhunk://#diff-21fbe64984a18c7c9fb221a28ca491bc64ad6ab2bc3d14d07291709047ebd0e5R73) [[4]](diffhunk://#diff-21fbe64984a18c7c9fb221a28ca491bc64ad6ab2bc3d14d07291709047ebd0e5R130-R136) [[5]](diffhunk://#diff-21fbe64984a18c7c9fb221a28ca491bc64ad6ab2bc3d14d07291709047ebd0e5L157-R171) [[6]](diffhunk://#diff-21fbe64984a18c7c9fb221a28ca491bc64ad6ab2bc3d14d07291709047ebd0e5R205-R206)